### PR TITLE
Adds support for specifying flag values via environment variables

### DIFF
--- a/internal/parser/bool.go
+++ b/internal/parser/bool.go
@@ -44,6 +44,7 @@ func NewBool(set *flag.FlagSet, field reflect.Value, tags reflect.StructTag) (*F
 			}
 
 			field.SetBool(envValue)
+			f.set = true
 		}
 	}
 

--- a/internal/parser/bool.go
+++ b/internal/parser/bool.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"flag"
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 )
@@ -31,6 +32,19 @@ func NewBool(set *flag.FlagSet, field reflect.Value, tags reflect.StructTag) (*F
 		set.BoolVar(field.Addr().Interface().(*bool), long, defaultValue, "")
 		f.flags = append(f.flags, set.Lookup(long))
 		f.name = fmt.Sprintf("--%s", long)
+	}
+
+	env, ok := tags.Lookup("env")
+	if ok {
+		envStr := os.Getenv(env)
+		if envStr != "" {
+			envValue, err := strconv.ParseBool(envStr)
+			if err != nil {
+				return &Flag{}, fmt.Errorf("could not parse bool environment variable %s value %q: %s", env, envStr, err)
+			}
+
+			field.SetBool(envValue)
+		}
 	}
 
 	_, f.required = tags.Lookup("required")

--- a/internal/parser/duration.go
+++ b/internal/parser/duration.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"flag"
 	"fmt"
+	"os"
 	"reflect"
 	"time"
 )
@@ -31,6 +32,19 @@ func NewDuration(set *flag.FlagSet, field reflect.Value, tags reflect.StructTag)
 		set.DurationVar(field.Addr().Interface().(*time.Duration), long, defaultValue, "")
 		f.flags = append(f.flags, set.Lookup(long))
 		f.name = fmt.Sprintf("--%s", long)
+	}
+
+	env, ok := tags.Lookup("env")
+	if ok {
+		envStr := os.Getenv(env)
+		if envStr != "" {
+			envValue, err := time.ParseDuration(envStr)
+			if err != nil {
+				return &Flag{}, fmt.Errorf("could not parse duration environment variable %s value %q: %s", env, envStr, err)
+			}
+
+			field.SetInt(int64(envValue))
+		}
 	}
 
 	_, f.required = tags.Lookup("required")

--- a/internal/parser/duration.go
+++ b/internal/parser/duration.go
@@ -44,6 +44,7 @@ func NewDuration(set *flag.FlagSet, field reflect.Value, tags reflect.StructTag)
 			}
 
 			field.SetInt(int64(envValue))
+			f.set = true
 		}
 	}
 

--- a/internal/parser/float64.go
+++ b/internal/parser/float64.go
@@ -44,6 +44,7 @@ func NewFloat64(set *flag.FlagSet, field reflect.Value, tags reflect.StructTag) 
 			}
 
 			field.SetFloat(envValue)
+			f.set = true
 		}
 	}
 

--- a/internal/parser/float64.go
+++ b/internal/parser/float64.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"flag"
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 )
@@ -31,6 +32,19 @@ func NewFloat64(set *flag.FlagSet, field reflect.Value, tags reflect.StructTag) 
 		set.Float64Var(field.Addr().Interface().(*float64), long, defaultValue, "")
 		f.flags = append(f.flags, set.Lookup(short))
 		f.name = fmt.Sprintf("--%s", long)
+	}
+
+	env, ok := tags.Lookup("env")
+	if ok {
+		envStr := os.Getenv(env)
+		if envStr != "" {
+			envValue, err := strconv.ParseFloat(envStr, 64)
+			if err != nil {
+				return &Flag{}, fmt.Errorf("could not parse float64 environment variable %s value %q: %s", env, envStr, err)
+			}
+
+			field.SetFloat(envValue)
+		}
 	}
 
 	_, f.required = tags.Lookup("required")

--- a/internal/parser/int.go
+++ b/internal/parser/int.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"flag"
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 )
@@ -31,6 +32,19 @@ func NewInt(set *flag.FlagSet, field reflect.Value, tags reflect.StructTag) (*Fl
 		set.IntVar(field.Addr().Interface().(*int), long, int(defaultValue), "")
 		f.flags = append(f.flags, set.Lookup(long))
 		f.name = fmt.Sprintf("--%s", long)
+	}
+
+	env, ok := tags.Lookup("env")
+	if ok {
+		envStr := os.Getenv(env)
+		if envStr != "" {
+			envValue, err := strconv.ParseInt(envStr, 0, 0)
+			if err != nil {
+				return &Flag{}, fmt.Errorf("could not parse int environment variable %s value %q: %s", env, envStr, err)
+			}
+
+			field.SetInt(envValue)
+		}
 	}
 
 	_, f.required = tags.Lookup("required")

--- a/internal/parser/int.go
+++ b/internal/parser/int.go
@@ -44,6 +44,7 @@ func NewInt(set *flag.FlagSet, field reflect.Value, tags reflect.StructTag) (*Fl
 			}
 
 			field.SetInt(envValue)
+			f.set = true
 		}
 	}
 

--- a/internal/parser/int64.go
+++ b/internal/parser/int64.go
@@ -44,6 +44,7 @@ func NewInt64(set *flag.FlagSet, field reflect.Value, tags reflect.StructTag) (*
 			}
 
 			field.SetInt(envValue)
+			f.set = true
 		}
 	}
 

--- a/internal/parser/int64.go
+++ b/internal/parser/int64.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"flag"
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 )
@@ -31,6 +32,19 @@ func NewInt64(set *flag.FlagSet, field reflect.Value, tags reflect.StructTag) (*
 		set.Int64Var(field.Addr().Interface().(*int64), long, defaultValue, "")
 		f.flags = append(f.flags, set.Lookup(long))
 		f.name = fmt.Sprintf("--%s", long)
+	}
+
+	env, ok := tags.Lookup("env")
+	if ok {
+		envStr := os.Getenv(env)
+		if envStr != "" {
+			envValue, err := strconv.ParseInt(envStr, 0, 64)
+			if err != nil {
+				return &Flag{}, fmt.Errorf("could not parse int64 environment variable %s value %q: %s", env, envStr, err)
+			}
+
+			field.SetInt(envValue)
+		}
 	}
 
 	_, f.required = tags.Lookup("required")

--- a/internal/parser/slice.go
+++ b/internal/parser/slice.go
@@ -40,6 +40,7 @@ func NewSlice(set *flag.FlagSet, field reflect.Value, tags reflect.StructTag) (*
 		if envStr != "" {
 			separated := strings.Split(envStr, ",")
 			*collection = append(*collection, separated...)
+			f.set = true
 		}
 	}
 

--- a/internal/parser/slice.go
+++ b/internal/parser/slice.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"flag"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 )
@@ -31,6 +32,15 @@ func NewSlice(set *flag.FlagSet, field reflect.Value, tags reflect.StructTag) (*
 		set.Var(&slice, long, "")
 		f.flags = append(f.flags, set.Lookup(long))
 		f.name = fmt.Sprintf("--%s", long)
+	}
+
+	env, ok := tags.Lookup("env")
+	if ok {
+		envStr := os.Getenv(env)
+		if envStr != "" {
+			separated := strings.Split(envStr, ",")
+			*collection = append(*collection, separated...)
+		}
 	}
 
 	_, f.required = tags.Lookup("required")

--- a/internal/parser/slice.go
+++ b/internal/parser/slice.go
@@ -36,8 +36,8 @@ func NewSlice(set *flag.FlagSet, field reflect.Value, tags reflect.StructTag) (*
 
 	env, ok := tags.Lookup("env")
 	if ok {
-		envStr := os.Getenv(env)
-		if envStr != "" {
+		envStr, ok := os.LookupEnv(env)
+		if ok {
 			separated := strings.Split(envStr, ",")
 			*collection = append(*collection, separated...)
 			f.set = true

--- a/internal/parser/string.go
+++ b/internal/parser/string.go
@@ -31,8 +31,8 @@ func NewString(set *flag.FlagSet, field reflect.Value, tags reflect.StructTag) (
 
 	env, ok := tags.Lookup("env")
 	if ok {
-		envStr := os.Getenv(env)
-		if envStr != "" {
+		envStr, ok := os.LookupEnv(env)
+		if ok {
 			field.SetString(envStr)
 			f.set = true
 		}

--- a/internal/parser/string.go
+++ b/internal/parser/string.go
@@ -34,6 +34,7 @@ func NewString(set *flag.FlagSet, field reflect.Value, tags reflect.StructTag) (
 		envStr := os.Getenv(env)
 		if envStr != "" {
 			field.SetString(envStr)
+			f.set = true
 		}
 	}
 

--- a/internal/parser/string.go
+++ b/internal/parser/string.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"flag"
 	"fmt"
+	"os"
 	"reflect"
 )
 
@@ -26,6 +27,14 @@ func NewString(set *flag.FlagSet, field reflect.Value, tags reflect.StructTag) (
 		set.StringVar(field.Addr().Interface().(*string), long, defaultValue, "")
 		f.flags = append(f.flags, set.Lookup(long))
 		f.name = fmt.Sprintf("--%s", long)
+	}
+
+	env, ok := tags.Lookup("env")
+	if ok {
+		envStr := os.Getenv(env)
+		if envStr != "" {
+			field.SetString(envStr)
+		}
 	}
 
 	_, f.required = tags.Lookup("required")

--- a/internal/parser/uint.go
+++ b/internal/parser/uint.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"flag"
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 )
@@ -31,6 +32,19 @@ func NewUint(set *flag.FlagSet, field reflect.Value, tags reflect.StructTag) (*F
 		set.UintVar(field.Addr().Interface().(*uint), long, uint(defaultValue), "")
 		f.flags = append(f.flags, set.Lookup(long))
 		f.name = fmt.Sprintf("--%s", long)
+	}
+
+	env, ok := tags.Lookup("env")
+	if ok {
+		envStr := os.Getenv(env)
+		if envStr != "" {
+			envValue, err := strconv.ParseUint(envStr, 0, 0)
+			if err != nil {
+				return &Flag{}, fmt.Errorf("could not parse uint environment variable %s value %q: %s", env, envStr, err)
+			}
+
+			field.SetUint(envValue)
+		}
 	}
 
 	_, f.required = tags.Lookup("required")

--- a/internal/parser/uint.go
+++ b/internal/parser/uint.go
@@ -44,6 +44,7 @@ func NewUint(set *flag.FlagSet, field reflect.Value, tags reflect.StructTag) (*F
 			}
 
 			field.SetUint(envValue)
+			f.set = true
 		}
 	}
 

--- a/internal/parser/uint64.go
+++ b/internal/parser/uint64.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"flag"
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 )
@@ -31,6 +32,19 @@ func NewUint64(set *flag.FlagSet, field reflect.Value, tags reflect.StructTag) (
 		set.Uint64Var(field.Addr().Interface().(*uint64), long, defaultValue, "")
 		f.flags = append(f.flags, set.Lookup(long))
 		f.name = fmt.Sprintf("--%s", long)
+	}
+
+	env, ok := tags.Lookup("env")
+	if ok {
+		envStr := os.Getenv(env)
+		if envStr != "" {
+			envValue, err := strconv.ParseUint(envStr, 0, 64)
+			if err != nil {
+				return &Flag{}, fmt.Errorf("could not parse uint64 environment variable %s value %q: %s", env, envStr, err)
+			}
+
+			field.SetUint(envValue)
+		}
 	}
 
 	_, f.required = tags.Lookup("required")

--- a/internal/parser/uint64.go
+++ b/internal/parser/uint64.go
@@ -44,6 +44,7 @@ func NewUint64(set *flag.FlagSet, field reflect.Value, tags reflect.StructTag) (
 			}
 
 			field.SetUint(envValue)
+			f.set = true
 		}
 	}
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,6 +1,7 @@
 package jhanda_test
 
 import (
+	"os"
 	"time"
 
 	"github.com/pivotal-cf/jhanda"
@@ -10,6 +11,11 @@ import (
 )
 
 var _ = Describe("Parse", func() {
+	AfterEach(func() {
+		os.Unsetenv("FIRST")
+		os.Unsetenv("SECOND")
+	})
+
 	Context("boolean flags", func() {
 		It("parses short name flags", func() {
 			var set struct {
@@ -35,6 +41,56 @@ var _ = Describe("Parse", func() {
 
 			Expect(set.First).To(BeFalse())
 			Expect(set.Second).To(BeTrue())
+		})
+
+		Context("when using environment variables", func() {
+			It("supports environment variables", func() {
+				var set struct {
+					First  bool `long:"first" env:"FIRST"`
+					Second bool `long:"second" env:"SECOND"`
+				}
+
+				os.Setenv("SECOND", "true")
+
+				args, err := jhanda.Parse(&set, []string{"command"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(args).To(Equal([]string{"command"}))
+
+				Expect(set.First).To(BeFalse())
+				Expect(set.Second).To(BeTrue())
+			})
+
+			Context("when the environment variable is overridden at the commandline", func() {
+				It("uses the commandline setting", func() {
+					var set struct {
+						First  bool `long:"first" env:"FIRST"`
+						Second bool `long:"second" env:"SECOND"`
+					}
+
+					os.Setenv("SECOND", "false")
+
+					args, err := jhanda.Parse(&set, []string{"--second", "command"})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(args).To(Equal([]string{"command"}))
+
+					Expect(set.First).To(BeFalse())
+					Expect(set.Second).To(BeTrue())
+				})
+			})
+
+			Context("when the environment variable is not a parsable boolean", func() {
+				It("returns an error", func() {
+					var set struct {
+						First  bool `long:"first" env:"FIRST"`
+						Second bool `long:"second" env:"SECOND"`
+					}
+
+					os.Setenv("SECOND", "banana")
+
+					_, err := jhanda.Parse(&set, []string{"--second", "command"})
+					Expect(err).To(MatchError(ContainSubstring("could not parse bool environment variable SECOND value \"banana\"")))
+				})
+			})
 		})
 
 		It("allows for setting a default value", func() {
@@ -109,6 +165,42 @@ var _ = Describe("Parse", func() {
 
 			Expect(set.First).To(BeEmpty())
 			Expect(set.Second).To(ConsistOf([]string{"test", "different-test"}))
+		})
+
+		Context("when using environment variables", func() {
+			It("supports environment variables", func() {
+				var set struct {
+					First  []string `long:"first"`
+					Second []string `long:"second" env:"SECOND"`
+				}
+
+				os.Setenv("SECOND", "test,different-test")
+
+				args, err := jhanda.Parse(&set, []string{"command"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(args).To(Equal([]string{"command"}))
+
+				Expect(set.First).To(BeEmpty())
+				Expect(set.Second).To(ConsistOf([]string{"test", "different-test"}))
+			})
+
+			Context("when the environment variable is overridden at the commandline", func() {
+				It("combines the settings", func() {
+					var set struct {
+						First  []string `long:"first"`
+						Second []string `long:"second" env:"SECOND"`
+					}
+
+					os.Setenv("SECOND", "test")
+
+					args, err := jhanda.Parse(&set, []string{"--second", "different-test", "command"})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(args).To(Equal([]string{"command"}))
+
+					Expect(set.First).To(BeEmpty())
+					Expect(set.Second).To(ConsistOf([]string{"test", "different-test"}))
+				})
+			})
 		})
 
 		It("allows for setting a default value", func() {
@@ -187,6 +279,56 @@ var _ = Describe("Parse", func() {
 			Expect(set.Second).To(Equal(12.3))
 		})
 
+		Context("when using environment variables", func() {
+			It("supports environment variables", func() {
+				var set struct {
+					First  float64 `long:"first"`
+					Second float64 `long:"second" env:"SECOND"`
+				}
+
+				os.Setenv("SECOND", "123.4")
+
+				args, err := jhanda.Parse(&set, []string{"command"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(args).To(Equal([]string{"command"}))
+
+				Expect(set.First).To(Equal(0.0))
+				Expect(set.Second).To(Equal(123.4))
+			})
+
+			Context("when the environment variable is overridden at the commandline", func() {
+				It("uses the commandline setting", func() {
+					var set struct {
+						First  float64 `long:"first"`
+						Second float64 `long:"second" env:"SECOND"`
+					}
+
+					os.Setenv("SECOND", "123.4")
+
+					args, err := jhanda.Parse(&set, []string{"--second", "567.8", "command"})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(args).To(Equal([]string{"command"}))
+
+					Expect(set.First).To(Equal(0.0))
+					Expect(set.Second).To(Equal(567.8))
+				})
+			})
+
+			Context("when the environment variable is set to a non-float value", func() {
+				It("returns an error", func() {
+					var set struct {
+						First  float64 `long:"first"`
+						Second float64 `long:"second" env:"SECOND"`
+					}
+
+					os.Setenv("SECOND", "banana")
+
+					_, err := jhanda.Parse(&set, []string{"command"})
+					Expect(err).To(MatchError(ContainSubstring("could not parse float64 environment variable SECOND value \"banana\"")))
+				})
+			})
+		})
+
 		Context("when a required flag is missing", func() {
 			It("returns an error", func() {
 				var set struct {
@@ -259,6 +401,56 @@ var _ = Describe("Parse", func() {
 
 			Expect(set.First).To(Equal(int64(123)))
 			Expect(set.Second).To(Equal(int64(999)))
+		})
+
+		Context("when using environment variables", func() {
+			It("supports environment variables", func() {
+				var set struct {
+					First  int64 `long:"first"`
+					Second int64 `long:"second" env:"SECOND"`
+				}
+
+				os.Setenv("SECOND", "123")
+
+				args, err := jhanda.Parse(&set, []string{"command"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(args).To(Equal([]string{"command"}))
+
+				Expect(set.First).To(Equal(int64(0)))
+				Expect(set.Second).To(Equal(int64(123)))
+			})
+
+			Context("when the environment variable is overridden at the commandline", func() {
+				It("uses the commandline setting", func() {
+					var set struct {
+						First  int64 `long:"first"`
+						Second int64 `long:"second" env:"SECOND"`
+					}
+
+					os.Setenv("SECOND", "123")
+
+					args, err := jhanda.Parse(&set, []string{"--second", "567", "command"})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(args).To(Equal([]string{"command"}))
+
+					Expect(set.First).To(Equal(int64(0)))
+					Expect(set.Second).To(Equal(int64(567)))
+				})
+			})
+
+			Context("when the environment variable is set to a non-int64 value", func() {
+				It("returns an error", func() {
+					var set struct {
+						First  int64 `long:"first"`
+						Second int64 `long:"second" env:"SECOND"`
+					}
+
+					os.Setenv("SECOND", "banana")
+
+					_, err := jhanda.Parse(&set, []string{"command"})
+					Expect(err).To(MatchError(ContainSubstring("could not parse int64 environment variable SECOND value \"banana\"")))
+				})
+			})
 		})
 
 		Context("when a required flag is missing", func() {
@@ -335,6 +527,56 @@ var _ = Describe("Parse", func() {
 			Expect(set.Second).To(Equal(42 * time.Hour))
 		})
 
+		Context("when using environment variables", func() {
+			It("supports environment variables", func() {
+				var set struct {
+					First  time.Duration `long:"first"`
+					Second time.Duration `long:"second" env:"SECOND"`
+				}
+
+				os.Setenv("SECOND", "42h")
+
+				args, err := jhanda.Parse(&set, []string{"command"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(args).To(Equal([]string{"command"}))
+
+				Expect(set.First).To(Equal(time.Duration(0)))
+				Expect(set.Second).To(Equal(42 * time.Hour))
+			})
+
+			Context("when the environment variable is overridden at the commandline", func() {
+				It("uses the commandline setting", func() {
+					var set struct {
+						First  time.Duration `long:"first"`
+						Second time.Duration `long:"second" env:"SECOND"`
+					}
+
+					os.Setenv("SECOND", "42h")
+
+					args, err := jhanda.Parse(&set, []string{"--second", "21m", "command"})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(args).To(Equal([]string{"command"}))
+
+					Expect(set.First).To(Equal(time.Duration(0)))
+					Expect(set.Second).To(Equal(21 * time.Minute))
+				})
+			})
+
+			Context("when the environment variable is set to a non-duration value", func() {
+				It("returns an error", func() {
+					var set struct {
+						First  time.Duration `long:"first"`
+						Second time.Duration `long:"second" env:"SECOND"`
+					}
+
+					os.Setenv("SECOND", "banana")
+
+					_, err := jhanda.Parse(&set, []string{"command"})
+					Expect(err).To(MatchError(ContainSubstring("could not parse duration environment variable SECOND value \"banana\"")))
+				})
+			})
+		})
+
 		Context("when a required flag is missing", func() {
 			It("returns an error", func() {
 				var set struct {
@@ -407,6 +649,56 @@ var _ = Describe("Parse", func() {
 
 			Expect(set.First).To(Equal(234))
 			Expect(set.Second).To(Equal(420))
+		})
+
+		Context("when using environment variables", func() {
+			It("supports environment variables", func() {
+				var set struct {
+					First  int `long:"first"`
+					Second int `long:"second" env:"SECOND"`
+				}
+
+				os.Setenv("SECOND", "42")
+
+				args, err := jhanda.Parse(&set, []string{"command"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(args).To(Equal([]string{"command"}))
+
+				Expect(set.First).To(Equal(0))
+				Expect(set.Second).To(Equal(42))
+			})
+
+			Context("when the environment variable is overridden at the commandline", func() {
+				It("uses the commandline setting", func() {
+					var set struct {
+						First  int `long:"first"`
+						Second int `long:"second" env:"SECOND"`
+					}
+
+					os.Setenv("SECOND", "42")
+
+					args, err := jhanda.Parse(&set, []string{"--second", "21", "command"})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(args).To(Equal([]string{"command"}))
+
+					Expect(set.First).To(Equal(0))
+					Expect(set.Second).To(Equal(21))
+				})
+			})
+
+			Context("when the environment variable is set to a non-int value", func() {
+				It("returns an error", func() {
+					var set struct {
+						First  int `long:"first"`
+						Second int `long:"second" env:"SECOND"`
+					}
+
+					os.Setenv("SECOND", "banana")
+
+					_, err := jhanda.Parse(&set, []string{"command"})
+					Expect(err).To(MatchError(ContainSubstring("could not parse int environment variable SECOND value \"banana\"")))
+				})
+			})
 		})
 
 		Context("when a required flag is missing", func() {
@@ -483,6 +775,42 @@ var _ = Describe("Parse", func() {
 			Expect(set.Second).To(Equal("custom"))
 		})
 
+		Context("when using environment variables", func() {
+			It("supports environment variables", func() {
+				var set struct {
+					First  string `long:"first"`
+					Second string `long:"second" env:"SECOND"`
+				}
+
+				os.Setenv("SECOND", "something")
+
+				args, err := jhanda.Parse(&set, []string{"command"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(args).To(Equal([]string{"command"}))
+
+				Expect(set.First).To(Equal(""))
+				Expect(set.Second).To(Equal("something"))
+			})
+
+			Context("when the environment variable is overridden at the commandline", func() {
+				It("uses the commandline setting", func() {
+					var set struct {
+						First  string `long:"first"`
+						Second string `long:"second" env:"SECOND"`
+					}
+
+					os.Setenv("SECOND", "something")
+
+					args, err := jhanda.Parse(&set, []string{"--second", "other-thing", "command"})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(args).To(Equal([]string{"command"}))
+
+					Expect(set.First).To(Equal(""))
+					Expect(set.Second).To(Equal("other-thing"))
+				})
+			})
+		})
+
 		Context("when a required flag is missing", func() {
 			It("returns an error", func() {
 				var set struct {
@@ -544,6 +872,56 @@ var _ = Describe("Parse", func() {
 
 			Expect(set.First).To(Equal(uint64(234)))
 			Expect(set.Second).To(Equal(uint64(420)))
+		})
+
+		Context("when using environment variables", func() {
+			It("supports environment variables", func() {
+				var set struct {
+					First  uint64 `long:"first"`
+					Second uint64 `long:"second" env:"SECOND"`
+				}
+
+				os.Setenv("SECOND", "42")
+
+				args, err := jhanda.Parse(&set, []string{"command"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(args).To(Equal([]string{"command"}))
+
+				Expect(set.First).To(Equal(uint64(0)))
+				Expect(set.Second).To(Equal(uint64(42)))
+			})
+
+			Context("when the environment variable is overridden at the commandline", func() {
+				It("uses the commandline setting", func() {
+					var set struct {
+						First  uint64 `long:"first"`
+						Second uint64 `long:"second" env:"SECOND"`
+					}
+
+					os.Setenv("SECOND", "42")
+
+					args, err := jhanda.Parse(&set, []string{"--second", "21", "command"})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(args).To(Equal([]string{"command"}))
+
+					Expect(set.First).To(Equal(uint64(0)))
+					Expect(set.Second).To(Equal(uint64(21)))
+				})
+			})
+
+			Context("when the environment variable is set to a non-uint64 value", func() {
+				It("returns an error", func() {
+					var set struct {
+						First  uint64 `long:"first"`
+						Second uint64 `long:"second" env:"SECOND"`
+					}
+
+					os.Setenv("SECOND", "banana")
+
+					_, err := jhanda.Parse(&set, []string{"command"})
+					Expect(err).To(MatchError(ContainSubstring("could not parse uint64 environment variable SECOND value \"banana\"")))
+				})
+			})
 		})
 
 		Context("when a required flag is missing", func() {
@@ -618,6 +996,56 @@ var _ = Describe("Parse", func() {
 
 			Expect(set.First).To(Equal(uint(234)))
 			Expect(set.Second).To(Equal(uint(420)))
+		})
+
+		Context("when using environment variables", func() {
+			It("supports environment variables", func() {
+				var set struct {
+					First  uint `long:"first"`
+					Second uint `long:"second" env:"SECOND"`
+				}
+
+				os.Setenv("SECOND", "42")
+
+				args, err := jhanda.Parse(&set, []string{"command"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(args).To(Equal([]string{"command"}))
+
+				Expect(set.First).To(Equal(uint(0)))
+				Expect(set.Second).To(Equal(uint(42)))
+			})
+
+			Context("when the environment variable is overridden at the commandline", func() {
+				It("uses the commandline setting", func() {
+					var set struct {
+						First  uint `long:"first"`
+						Second uint `long:"second" env:"SECOND"`
+					}
+
+					os.Setenv("SECOND", "42")
+
+					args, err := jhanda.Parse(&set, []string{"--second", "21", "command"})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(args).To(Equal([]string{"command"}))
+
+					Expect(set.First).To(Equal(uint(0)))
+					Expect(set.Second).To(Equal(uint(21)))
+				})
+			})
+
+			Context("when the environment variable is set to a non-uint value", func() {
+				It("returns an error", func() {
+					var set struct {
+						First  uint `long:"first"`
+						Second uint `long:"second" env:"SECOND"`
+					}
+
+					os.Setenv("SECOND", "banana")
+
+					_, err := jhanda.Parse(&set, []string{"command"})
+					Expect(err).To(MatchError(ContainSubstring("could not parse uint environment variable SECOND value \"banana\"")))
+				})
+			})
 		})
 
 		Context("when a required flag is missing", func() {

--- a/parse_test.go
+++ b/parse_test.go
@@ -236,6 +236,22 @@ var _ = Describe("Parse", func() {
 					Expect(set.First).To(BeEmpty())
 					Expect(set.Second).To(ConsistOf([]string{"test", "different-test"}))
 				})
+
+				It("allows it to be empty set via environment variable", func() {
+					var set struct {
+						First  []string `long:"first"`
+						Second []string `long:"second" env:"SECOND" required:"true"`
+					}
+
+					os.Setenv("SECOND", "")
+
+					args, err := jhanda.Parse(&set, []string{"command"})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(args).To(Equal([]string{"command"}))
+
+					Expect(set.First).To(BeEmpty())
+					Expect(set.Second).To(ConsistOf(BeEmpty()))
+				})
 			})
 		})
 
@@ -933,6 +949,22 @@ var _ = Describe("Parse", func() {
 
 					Expect(set.First).To(Equal(""))
 					Expect(set.Second).To(Equal("something"))
+				})
+
+				It("allows it to be empty set via environment variable", func() {
+					var set struct {
+						First  string `long:"first"`
+						Second string `long:"second" env:"SECOND" required:"true"`
+					}
+
+					os.Setenv("SECOND", "")
+
+					args, err := jhanda.Parse(&set, []string{"command"})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(args).To(Equal([]string{"command"}))
+
+					Expect(set.First).To(Equal(""))
+					Expect(set.Second).To(Equal(""))
 				})
 			})
 		})

--- a/parse_test.go
+++ b/parse_test.go
@@ -78,6 +78,24 @@ var _ = Describe("Parse", func() {
 				})
 			})
 
+			Context("when the field is required", func() {
+				It("allows it to be set via environment variable", func() {
+					var set struct {
+						First  bool `long:"first" env:"FIRST"`
+						Second bool `long:"second" env:"SECOND" required:"true"`
+					}
+
+					os.Setenv("SECOND", "true")
+
+					args, err := jhanda.Parse(&set, []string{"command"})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(args).To(Equal([]string{"command"}))
+
+					Expect(set.First).To(BeFalse())
+					Expect(set.Second).To(BeTrue())
+				})
+			})
+
 			Context("when the environment variable is not a parsable boolean", func() {
 				It("returns an error", func() {
 					var set struct {
@@ -201,6 +219,24 @@ var _ = Describe("Parse", func() {
 					Expect(set.Second).To(ConsistOf([]string{"test", "different-test"}))
 				})
 			})
+
+			Context("when the field is required", func() {
+				It("allows it to be set via environment variable", func() {
+					var set struct {
+						First  []string `long:"first"`
+						Second []string `long:"second" env:"SECOND" required:"true"`
+					}
+
+					os.Setenv("SECOND", "test,different-test")
+
+					args, err := jhanda.Parse(&set, []string{"command"})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(args).To(Equal([]string{"command"}))
+
+					Expect(set.First).To(BeEmpty())
+					Expect(set.Second).To(ConsistOf([]string{"test", "different-test"}))
+				})
+			})
 		})
 
 		It("allows for setting a default value", func() {
@@ -311,6 +347,24 @@ var _ = Describe("Parse", func() {
 
 					Expect(set.First).To(Equal(0.0))
 					Expect(set.Second).To(Equal(567.8))
+				})
+			})
+
+			Context("when the field is required", func() {
+				It("allows it to be set via environment variable", func() {
+					var set struct {
+						First  float64 `long:"first"`
+						Second float64 `long:"second" env:"SECOND" required:"true"`
+					}
+
+					os.Setenv("SECOND", "123.4")
+
+					args, err := jhanda.Parse(&set, []string{"command"})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(args).To(Equal([]string{"command"}))
+
+					Expect(set.First).To(Equal(0.0))
+					Expect(set.Second).To(Equal(123.4))
 				})
 			})
 
@@ -438,6 +492,24 @@ var _ = Describe("Parse", func() {
 				})
 			})
 
+			Context("when the field is required", func() {
+				It("allows it to be set via environment variable", func() {
+					var set struct {
+						First  int64 `long:"first"`
+						Second int64 `long:"second" env:"SECOND" required:"true"`
+					}
+
+					os.Setenv("SECOND", "123")
+
+					args, err := jhanda.Parse(&set, []string{"command"})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(args).To(Equal([]string{"command"}))
+
+					Expect(set.First).To(Equal(int64(0)))
+					Expect(set.Second).To(Equal(int64(123)))
+				})
+			})
+
 			Context("when the environment variable is set to a non-int64 value", func() {
 				It("returns an error", func() {
 					var set struct {
@@ -559,6 +631,24 @@ var _ = Describe("Parse", func() {
 
 					Expect(set.First).To(Equal(time.Duration(0)))
 					Expect(set.Second).To(Equal(21 * time.Minute))
+				})
+			})
+
+			Context("when the field is required", func() {
+				It("allows it to be set via environment variable", func() {
+					var set struct {
+						First  time.Duration `long:"first"`
+						Second time.Duration `long:"second" env:"SECOND" required:"true"`
+					}
+
+					os.Setenv("SECOND", "42h")
+
+					args, err := jhanda.Parse(&set, []string{"command"})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(args).To(Equal([]string{"command"}))
+
+					Expect(set.First).To(Equal(time.Duration(0)))
+					Expect(set.Second).To(Equal(42 * time.Hour))
 				})
 			})
 
@@ -686,6 +776,24 @@ var _ = Describe("Parse", func() {
 				})
 			})
 
+			Context("when the field is required", func() {
+				It("allows it to be set via environment variable", func() {
+					var set struct {
+						First  int `long:"first"`
+						Second int `long:"second" env:"SECOND" required:"true"`
+					}
+
+					os.Setenv("SECOND", "42")
+
+					args, err := jhanda.Parse(&set, []string{"command"})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(args).To(Equal([]string{"command"}))
+
+					Expect(set.First).To(Equal(0))
+					Expect(set.Second).To(Equal(42))
+				})
+			})
+
 			Context("when the environment variable is set to a non-int value", func() {
 				It("returns an error", func() {
 					var set struct {
@@ -809,6 +917,24 @@ var _ = Describe("Parse", func() {
 					Expect(set.Second).To(Equal("other-thing"))
 				})
 			})
+
+			Context("when the field is required", func() {
+				It("allows it to be set via environment variable", func() {
+					var set struct {
+						First  string `long:"first"`
+						Second string `long:"second" env:"SECOND" required:"true"`
+					}
+
+					os.Setenv("SECOND", "something")
+
+					args, err := jhanda.Parse(&set, []string{"command"})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(args).To(Equal([]string{"command"}))
+
+					Expect(set.First).To(Equal(""))
+					Expect(set.Second).To(Equal("something"))
+				})
+			})
 		})
 
 		Context("when a required flag is missing", func() {
@@ -906,6 +1032,24 @@ var _ = Describe("Parse", func() {
 
 					Expect(set.First).To(Equal(uint64(0)))
 					Expect(set.Second).To(Equal(uint64(21)))
+				})
+			})
+
+			Context("when the field is required", func() {
+				It("allows it to be set via environment variable", func() {
+					var set struct {
+						First  uint64 `long:"first"`
+						Second uint64 `long:"second" env:"SECOND" required:"true"`
+					}
+
+					os.Setenv("SECOND", "42")
+
+					args, err := jhanda.Parse(&set, []string{"command"})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(args).To(Equal([]string{"command"}))
+
+					Expect(set.First).To(Equal(uint64(0)))
+					Expect(set.Second).To(Equal(uint64(42)))
 				})
 			})
 
@@ -1030,6 +1174,24 @@ var _ = Describe("Parse", func() {
 
 					Expect(set.First).To(Equal(uint(0)))
 					Expect(set.Second).To(Equal(uint(21)))
+				})
+			})
+
+			Context("when the field is required", func() {
+				It("allows it to be set via environment variable", func() {
+					var set struct {
+						First  uint `long:"first"`
+						Second uint `long:"second" env:"SECOND" required:"true"`
+					}
+
+					os.Setenv("SECOND", "42")
+
+					args, err := jhanda.Parse(&set, []string{"command"})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(args).To(Equal([]string{"command"}))
+
+					Expect(set.First).To(Equal(uint(0)))
+					Expect(set.Second).To(Equal(uint(42)))
 				})
 			})
 

--- a/usage.go
+++ b/usage.go
@@ -33,25 +33,33 @@ func PrintUsage(receiver interface{}) (string, error) {
 	var usage []string
 	var length int
 	for _, field := range fields {
-		var longShort string
+		var longShortEnv string
 		long, ok := field.Tag.Lookup("long")
 		if ok {
-			longShort += fmt.Sprintf("--%s", long)
+			longShortEnv += fmt.Sprintf("--%s", long)
 		}
 
 		short, ok := field.Tag.Lookup("short")
 		if ok {
-			if longShort != "" {
-				longShort += ", "
+			if longShortEnv != "" {
+				longShortEnv += ", "
 			}
-			longShort += fmt.Sprintf("-%s", short)
+			longShortEnv += fmt.Sprintf("-%s", short)
 		}
 
-		if len(longShort) > length {
-			length = len(longShort)
+		env, ok := field.Tag.Lookup("env")
+		if ok {
+			if longShortEnv != "" {
+				longShortEnv += ", "
+			}
+			longShortEnv += fmt.Sprintf("%s", env)
 		}
 
-		usage = append(usage, longShort)
+		if len(longShortEnv) > length {
+			length = len(longShortEnv)
+		}
+
+		usage = append(usage, longShortEnv)
 	}
 
 	for i, line := range usage {

--- a/usage_test.go
+++ b/usage_test.go
@@ -12,15 +12,15 @@ import (
 var _ = Describe("Usage", func() {
 	It("returns a formatted version of the flag set usage", func() {
 		usage, err := jhanda.PrintUsage(struct {
-			Second []string `short:"2" long:"second" required:"true" default:"true"  description:"the second flag"`
-			Third  string   `          long:"third"                                  description:"the third flag"`
-			First  bool     `short:"1" long:"first"  required:"true"                 description:"the first flag"`
+			Second []string `short:"2" long:"second" required:"true" default:"true" description:"the second flag"`
+			Third  string   `          long:"third"                  env:"THIRD"    description:"the third flag"`
+			First  bool     `short:"1" long:"first"  required:"true"                description:"the first flag"`
 		}{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(usage).To(Equal(strings.TrimSpace(`
---first, -1   bool (required)              the first flag
---second, -2  string (required, variadic)  the second flag (default: true)
---third       string                       the third flag
+--first, -1     bool (required)              the first flag
+--second, -2    string (required, variadic)  the second flag (default: true)
+--third, THIRD  string                       the third flag
 `)))
 	})
 


### PR DESCRIPTION
With this PR, you can now specify an environment variable for a flag like the following:
```go
var flags struct{
  Fruit string `short:"f" long:"fruit" env:"FRUIT"`
}
jhanda.Parse(&flags)
fmt.Printf("My favorite fruit is %s.", flags.Fruit)
```

You can then run your command with an environment variable assigned like the following:
```
$ FRUIT=banana my-command
My favorite fruit is banana.
```

Flags specified directly will still have precedence like the following shows:
```
$ FRUIT=banana my-command --fruit pineapple
My favorite fruit is pineapple.
```